### PR TITLE
Allow the user to pass a folder name in which the private action will be cloned

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   private-action-token:
     description: 'Token to access the private repository'
     required: true
+  private-action-folder:
+    description: 'Folder in which to clone the private action'
+    required: false
 runs:
   using: 'node12'
   main: 'dist/main.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -127,6 +127,9 @@ async function checkoutCode() {
     // Read `private-action-token` input parmeter
     const token = core.getInput('private-action-token');
 
+    // Read `private-action-folder` input parameter
+    const folder = core.getInput('private-action-folder');
+
     // If `private-action` input prameter is missing, return an error
     if (!action) {
         core.setFailed(`Missing 'private-action' input parameter`);
@@ -158,7 +161,7 @@ async function checkoutCode() {
     }
 
     // Create a random folder name where to checkout the action
-    const tempFolderName = randomFolderName();
+    const tempFolderName = folder || randomFolderName();
 
     try {
         // Generate repository URL for the action to checkout


### PR DESCRIPTION
Hi,

Thanks again for the very useful action.

I'd like to ease the access to the code in the private action being cloned.
In order to do that, I would like to be able to pass an input `private-action-folder` that would be used to clone the private action in. This is not required, hence if not provided, the action is cloned in a folder with a random name.

Let me know what you think about it.

Cheers,